### PR TITLE
[#166028126] Implement multiple modes of issuer claim validation

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/provider/AbstractXOAuthIdentityProviderDefinition.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/provider/AbstractXOAuthIdentityProviderDefinition.java
@@ -35,6 +35,8 @@ public abstract class AbstractXOAuthIdentityProviderDefinition<T extends Abstrac
     private String relyingPartySecret;
     private List<String> scopes;
     private String issuer;
+
+    private XOAuthIssuerValidationMode issuerValidationMode = XOAuthIssuerValidationMode.STRICT;
     private String responseType = "code";
 
     public URL getAuthUrl() {
@@ -146,6 +148,13 @@ public abstract class AbstractXOAuthIdentityProviderDefinition<T extends Abstrac
         return (T) this;
     }
 
+    public XOAuthIssuerValidationMode getIssuerValidationMode() { return issuerValidationMode; }
+
+    public T setIssuerValidationMode(XOAuthIssuerValidationMode issuerValidationMode) {
+        this.issuerValidationMode = issuerValidationMode;
+        return (T) this;
+    }
+
     public String getResponseType() {
         return responseType;
     }
@@ -183,6 +192,7 @@ public abstract class AbstractXOAuthIdentityProviderDefinition<T extends Abstrac
             return false;
         if (scopes != null ? !scopes.equals(that.scopes) : that.scopes != null) return false;
         if (issuer != null ? !issuer.equals(that.issuer) : that.issuer != null) return false;
+        if (issuerValidationMode != null ? !issuerValidationMode.equals(that.issuerValidationMode) : that.issuerValidationMode != null) return false;
         return responseType != null ? responseType.equals(that.responseType) : that.responseType == null;
 
     }
@@ -201,6 +211,7 @@ public abstract class AbstractXOAuthIdentityProviderDefinition<T extends Abstrac
         result = 31 * result + (relyingPartySecret != null ? relyingPartySecret.hashCode() : 0);
         result = 31 * result + (scopes != null ? scopes.hashCode() : 0);
         result = 31 * result + (issuer != null ? issuer.hashCode() : 0);
+        result = 31 * result + (issuerValidationMode != null ? issuerValidationMode.hashCode() : 0);
         result = 31 * result + (responseType != null ? responseType.hashCode() : 0);
         return result;
     }

--- a/model/src/main/java/org/cloudfoundry/identity/uaa/provider/XOAuthIssuerValidationMode.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/provider/XOAuthIssuerValidationMode.java
@@ -1,0 +1,6 @@
+package org.cloudfoundry.identity.uaa.provider;
+
+public enum XOAuthIssuerValidationMode {
+    STRICT,
+    DOMAIN_ONLY
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/TokenValidationService.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/TokenValidationService.java
@@ -2,6 +2,7 @@ package org.cloudfoundry.identity.uaa.oauth;
 
 import org.cloudfoundry.identity.uaa.oauth.token.RevocableToken;
 import org.cloudfoundry.identity.uaa.oauth.token.RevocableTokenProvisioning;
+import org.cloudfoundry.identity.uaa.provider.XOAuthIssuerValidationMode;
 import org.cloudfoundry.identity.uaa.user.UaaUser;
 import org.cloudfoundry.identity.uaa.user.UaaUserDatabase;
 import org.cloudfoundry.identity.uaa.util.TokenValidation;
@@ -52,7 +53,7 @@ public class TokenValidationService {
                 buildAccessTokenValidator(token, keyInfoService) : buildRefreshTokenValidator(token, keyInfoService);
         tokenValidation
                 .checkRevocableTokenStore(revocableTokenProvisioning)
-                .checkIssuer(tokenEndpointBuilder.getTokenEndpoint());
+                .checkIssuer(tokenEndpointBuilder.getTokenEndpoint(), XOAuthIssuerValidationMode.STRICT);
 
         ClientDetails client = tokenValidation.getClientDetails(multitenantClientServices);
         UaaUser user = tokenValidation.getUserDetails(userDatabase);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIDPWrapperFactoryBean.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIDPWrapperFactoryBean.java
@@ -19,6 +19,7 @@ import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
 import org.cloudfoundry.identity.uaa.provider.IdentityProviderWrapper;
 import org.cloudfoundry.identity.uaa.provider.OIDCIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.provider.RawXOAuthIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.XOAuthIssuerValidationMode;
 import org.cloudfoundry.identity.uaa.util.JsonUtils;
 
 import java.net.MalformedURLException;
@@ -109,6 +110,18 @@ public class OauthIDPWrapperFactoryBean {
         idpDefinition.setSkipSslValidation(idpDefinitionMap.get("skipSslValidation") == null ? false : (boolean) idpDefinitionMap.get("skipSslValidation"));
         idpDefinition.setTokenKey((String) idpDefinitionMap.get("tokenKey"));
         idpDefinition.setIssuer((String) idpDefinitionMap.get("issuer"));
+
+        XOAuthIssuerValidationMode issuerValidationMode = XOAuthIssuerValidationMode.STRICT;
+        String issuerValidationModeText = (String)idpDefinitionMap.get("issuerValidationMode");
+        if (hasText(issuerValidationModeText)) {
+            try {
+                issuerValidationMode = XOAuthIssuerValidationMode.valueOf(issuerValidationModeText.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("issuer validation mode is malformed.", e);
+            }
+        }
+        idpDefinition.setIssuerValidationMode(issuerValidationMode);
+
         idpDefinition.setAttributeMappings((Map<String, Object>) idpDefinitionMap.get(ATTRIBUTE_MAPPINGS));
         idpDefinition.setScopes((List<String>) idpDefinitionMap.get("scopes"));
         String responseType = (String) idpDefinitionMap.get("responseType");

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthAuthenticationManager.java
@@ -17,6 +17,11 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.cloudfoundry.identity.uaa.provider.AbstractXOAuthIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
+import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
+import org.cloudfoundry.identity.uaa.provider.OIDCIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.RawXOAuthIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
 import org.cloudfoundry.identity.uaa.authentication.manager.ExternalGroupAuthorizationEvent;
 import org.cloudfoundry.identity.uaa.authentication.manager.ExternalLoginAuthenticationManager;
@@ -31,11 +36,6 @@ import org.cloudfoundry.identity.uaa.oauth.jwt.ChainedSignatureVerifier;
 import org.cloudfoundry.identity.uaa.oauth.jwt.Jwt;
 import org.cloudfoundry.identity.uaa.oauth.jwt.JwtHelper;
 import org.cloudfoundry.identity.uaa.oauth.token.ClaimConstants;
-import org.cloudfoundry.identity.uaa.provider.AbstractXOAuthIdentityProviderDefinition;
-import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
-import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
-import org.cloudfoundry.identity.uaa.provider.OIDCIdentityProviderDefinition;
-import org.cloudfoundry.identity.uaa.provider.RawXOAuthIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.user.UaaUser;
 import org.cloudfoundry.identity.uaa.user.UaaUserPrototype;
 import org.cloudfoundry.identity.uaa.util.JsonUtils;
@@ -527,7 +527,7 @@ public class XOAuthAuthenticationManager extends ExternalLoginAuthenticationMana
         } else {
             JsonWebKeySet<JsonWebKey> tokenKeyFromOAuth = getTokenKeyFromOAuth(config);
             validation = buildIdTokenValidator(idToken, new ChainedSignatureVerifier(tokenKeyFromOAuth), keyInfoService)
-                .checkIssuer((isEmpty(config.getIssuer()) ? config.getTokenUrl().toString() : config.getIssuer()))
+                .checkIssuer((isEmpty(config.getIssuer()) ? config.getTokenUrl().toString() : config.getIssuer()), config.getIssuerValidationMode())
                 .checkAudience(config.getRelyingPartyId());
         }
         return validation.checkExpiry();

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/TokenValidation.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/TokenValidation.java
@@ -15,6 +15,7 @@ package org.cloudfoundry.identity.uaa.util;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.cloudfoundry.identity.uaa.provider.XOAuthIssuerValidationMode;
 import org.cloudfoundry.identity.uaa.oauth.KeyInfo;
 import org.cloudfoundry.identity.uaa.oauth.KeyInfoService;
 import org.cloudfoundry.identity.uaa.oauth.TokenRevokedException;
@@ -39,6 +40,8 @@ import org.springframework.security.oauth2.provider.NoSuchClientException;
 import org.springframework.util.Assert;
 
 import javax.validation.constraints.NotNull;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.time.Instant;
 import java.util.*;
 import java.util.function.Function;
@@ -124,7 +127,7 @@ public abstract class TokenValidation {
         return this;
     }
 
-    public TokenValidation checkIssuer(String issuer) {
+    public TokenValidation checkIssuer(String issuer, XOAuthIssuerValidationMode validationMode) {
         if (issuer == null) {
             return this;
         }
@@ -133,10 +136,40 @@ public abstract class TokenValidation {
             throw new InvalidTokenException("Token does not bear an ISS claim.", null);
         }
 
-        if (!equals(issuer, claims.get(ISS))) {
-            throw new InvalidTokenException("Invalid issuer (" + claims.get(ISS) + ") for token did not match expected: " + issuer, null);
+        switch (validationMode) {
+            case STRICT: {
+                if (!equals(issuer, claims.get(ISS))) {
+                    throw new InvalidTokenException("Invalid issuer (" + claims.get(ISS) + ") for token did not match expected: " + issuer, null);
+                }
+                return this;
+            }
+            case DOMAIN_ONLY: {
+                URL issuerUrl;
+                try {
+                    issuerUrl = new URL(issuer);
+                }
+                catch (MalformedURLException e) {
+                    throw new InvalidTokenException("Issuer is a malformed URL.", e);
+                }
+
+                URL claimUrl;
+                try
+                {
+                    claimUrl = new URL((String)claims.get(ISS));
+                }
+                catch (MalformedURLException e) {
+                    throw new InvalidTokenException("Issuer claim is a malformed URL.", e);
+                }
+
+                if (!equals(issuerUrl.getHost(), claimUrl.getHost())) {
+                    throw new InvalidTokenException("Invalid issuer domain (" + claimUrl.getHost() + ") for token did not match expected: " + issuerUrl.getHost(), null);
+                }
+                return this;
+            }
+            default: {
+                throw new IllegalArgumentException("Unknown enum value: " + validationMode);
+            }
         }
-        return this;
     }
 
     protected TokenValidation checkExpiry(Instant asOf) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/TokenValidationServiceTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/TokenValidationServiceTest.java
@@ -125,6 +125,24 @@ public class TokenValidationServiceTest {
     }
 
     @Test
+    public void validationFails_whenIssuerDoesNotMatchTokenEndPointExactly() {
+        String tokenEndpoint = "https://token.endpoint";
+        String issuer = tokenEndpoint + "/does/not/match";
+
+        when(tokenEndpointBuilder.getTokenEndpoint()).thenReturn(tokenEndpoint);
+
+        expectedException.expect(InvalidTokenException.class);
+        expectedException.expectMessage("Invalid issuer (" + issuer + ") for token did not match expected: " + tokenEndpoint);
+
+        content.put(ISS, issuer);
+
+        when(mockMultitenantClientServices.loadClientByClientId(clientId, IdentityZoneHolder.get().getId())).thenThrow(NoSuchClientException.class);
+        String accessToken = UaaTokenUtils.constructToken(header, content, signer);
+
+        tokenValidationService.validateToken(accessToken, true);
+    }
+
+    @Test
     public void refreshToken_validatesWithScopeClaim_forBackwardsCompatibilityReasons() {
         Map<String, Object> content = map(
                 entry(USER_ID, userId),

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthAuthenticationManagerIT.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthAuthenticationManagerIT.java
@@ -222,6 +222,7 @@ public class XOAuthAuthenticationManagerIT {
                 .setAuthUrl(new URL("http://localhost/oauth/authorize"))
                 .setTokenUrl(new URL("http://localhost/oauth/token"))
                 .setIssuer("http://localhost/oauth/token")
+                .setIssuerValidationMode(XOAuthIssuerValidationMode.STRICT)
                 .setShowLinkText(true)
                 .setLinkText("My OIDC Provider")
                 .setRelyingPartyId("identity")

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/TokenValidationTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/TokenValidationTest.java
@@ -24,6 +24,7 @@ import org.cloudfoundry.identity.uaa.oauth.jwt.ChainedSignatureVerifier;
 import org.cloudfoundry.identity.uaa.oauth.token.ClaimConstants;
 import org.cloudfoundry.identity.uaa.oauth.token.RevocableToken;
 import org.cloudfoundry.identity.uaa.oauth.token.RevocableTokenProvisioning;
+import org.cloudfoundry.identity.uaa.provider.XOAuthIssuerValidationMode;
 import org.cloudfoundry.identity.uaa.test.TestUtils;
 import org.cloudfoundry.identity.uaa.user.InMemoryUaaUserDatabase;
 import org.cloudfoundry.identity.uaa.user.MockUaaUserDatabase;
@@ -339,7 +340,7 @@ public class TokenValidationTest {
     @Test
     public void checking_token_happy_case() {
         buildAccessTokenValidator(getToken(), new KeyInfoService("https://localhost"))
-                .checkIssuer("http://localhost:8080/uaa/oauth/token")
+                .checkIssuer("http://localhost:8080/uaa/oauth/token", XOAuthIssuerValidationMode.STRICT)
                 .checkClient((clientId) -> inMemoryMultitenantClientServices.loadClientByClientId(clientId))
                 .checkExpiry(oneSecondBeforeTheTokenExpires)
                 .checkUser((uid) -> userDb.retrieveUserById(uid))
@@ -385,7 +386,7 @@ public class TokenValidationTest {
         buildAccessTokenValidator(
                 getToken(Arrays.asList(EMAIL, USER_NAME)), new KeyInfoService("https://localhost"))
                 .checkSignature(verifier)
-                .checkIssuer("http://localhost:8080/uaa/oauth/token")
+                .checkIssuer("http://localhost:8080/uaa/oauth/token", XOAuthIssuerValidationMode.STRICT)
                 .checkClient((clientId) -> inMemoryMultitenantClientServices.loadClientByClientId(clientId))
                 .checkExpiry(oneSecondBeforeTheTokenExpires)
                 .checkUser((uid) -> userDb.retrieveUserById(uid))
@@ -438,10 +439,18 @@ public class TokenValidationTest {
     }
 
     @Test
-    public void tokenWithInvalidIssuer() {
+    public void tokenWithInvalidIssuer_AndStrictIssuerValidation() {
         expectedException.expect(InvalidTokenException.class);
 
-        buildAccessTokenValidator(getToken(), new KeyInfoService("https://localhost")).checkIssuer("http://wrong.issuer/");
+        buildAccessTokenValidator(getToken(), new KeyInfoService("https://localhost")).checkIssuer("http://wrong.issuer/", XOAuthIssuerValidationMode.STRICT);
+    }
+
+    @Test
+    public void tokenWithMatchingDomain_andDomainOnlyIssuerValidation_passesValidation() {
+        buildAccessTokenValidator(
+            getToken(),
+            new KeyInfoService("https://localhost")
+        ).checkIssuer("http://localhost/another/path/segment", XOAuthIssuerValidationMode.DOMAIN_ONLY);
     }
 
     @Test
@@ -450,7 +459,7 @@ public class TokenValidationTest {
         TokenValidation validation = buildAccessTokenValidator(getToken(), new KeyInfoService("https://localhost"));
 
         expectedException.expect(InvalidTokenException.class);
-        validation.checkIssuer("http://localhost:8080/uaa/oauth/token");
+        validation.checkIssuer("http://localhost:8080/uaa/oauth/token", XOAuthIssuerValidationMode.STRICT);
     }
 
     @Test


### PR DESCRIPTION
What
---
Some IDPs (e.g. Microsoft) create tokens whose `iss` claim can vary from user
to user. Under the current version, UAA was unable to integrate with these
providers because it requires a single, specific issuer value to be present.

To enable UAA to integrate with providers who do this, we implement different
modes for validating the `iss` claim, under the `issuerValidationMode`
configuration property for OIDC providers

The modes are

STRICT
  The default behaviour. The string in the `iss` claim and the configured
  issuer URL must match exactly.

DOMAIN_ONLY
  The value of the `iss` claim and the configured issuer URL must be URLs. They
  are considered to match if their domains match. Subdomains are not considered
  to match a parent domain.

NONE
  The `iss` claims is always considered to be valid.

How to review
---
1. Code review
2. Run the tests via `./gradlew test`

We found that the shell scripts `./run-{unit,integration}-tests.sh` weren't reliable, even in a freshly checked out copy of `cloudfoundry/uaa`. We assume this is because we're missing some environment config. Running the tests via gradle was more reliable.

Who can review
---
Someone with some Java, and ideally UAA, knowledge