### PR TITLE
Revert "Make bcrypt migrations not overwrite existing"

### DIFF
--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/postgresql/V4_99_1561608282__Migrate_Clients_To_Spring_Security_5.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/postgresql/V4_99_1561608282__Migrate_Clients_To_Spring_Security_5.sql
@@ -1,3 +1,2 @@
 UPDATE oauth_client_details
 SET client_secret = CONCAT('{bcrypt}', client_secret)
-WHERE client_secret NOT ilike '{bcrypt}%'

--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/postgresql/V4_99_1561658666__Migrate_Users_To_Spring_Security_5.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/postgresql/V4_99_1561658666__Migrate_Users_To_Spring_Security_5.sql
@@ -1,3 +1,2 @@
 UPDATE users
 SET password = CONCAT('{bcrypt}', password)
-WHERE password NOT ilike '{bcrypt}%'


### PR DESCRIPTION
This reverts commit 1cdf941a624c661d77c31c8c289c2d3efab251b7.

These migrations have now run safely in staging and prod, so we should use the same ones as upstream, with the same checksum, so that future migrations continue to work.