### PR TITLE
Redirect all prefixes of "/passcode" to help users

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/provider/AbstractXOAuthIdentityProviderDefinition.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/provider/AbstractXOAuthIdentityProviderDefinition.java
@@ -36,6 +36,8 @@ public abstract class AbstractXOAuthIdentityProviderDefinition<T extends Abstrac
     private String relyingPartySecret;
     private List<String> scopes;
     private String issuer;
+
+    private XOAuthIssuerValidationMode issuerValidationMode = XOAuthIssuerValidationMode.STRICT;
     private String responseType = "code";
 
     public URL getAuthUrl() {
@@ -147,6 +149,13 @@ public abstract class AbstractXOAuthIdentityProviderDefinition<T extends Abstrac
         return (T) this;
     }
 
+    public XOAuthIssuerValidationMode getIssuerValidationMode() { return issuerValidationMode; }
+
+    public T setIssuerValidationMode(XOAuthIssuerValidationMode issuerValidationMode) {
+        this.issuerValidationMode = issuerValidationMode;
+        return (T) this;
+    }
+
     public String getResponseType() {
         return responseType;
     }
@@ -184,6 +193,7 @@ public abstract class AbstractXOAuthIdentityProviderDefinition<T extends Abstrac
             return false;
         if (!Objects.equals(scopes, that.scopes)) return false;
         if (!Objects.equals(issuer, that.issuer)) return false;
+        if (!Objects.equals(issuerValidationMode, that.issuerValidationMode)) return false;
         return Objects.equals(responseType, that.responseType);
 
     }
@@ -202,6 +212,7 @@ public abstract class AbstractXOAuthIdentityProviderDefinition<T extends Abstrac
         result = 31 * result + (relyingPartySecret != null ? relyingPartySecret.hashCode() : 0);
         result = 31 * result + (scopes != null ? scopes.hashCode() : 0);
         result = 31 * result + (issuer != null ? issuer.hashCode() : 0);
+        result = 31 * result + (issuerValidationMode != null ? issuerValidationMode.hashCode() : 0);
         result = 31 * result + (responseType != null ? responseType.hashCode() : 0);
         return result;
     }

--- a/model/src/main/java/org/cloudfoundry/identity/uaa/provider/XOAuthIssuerValidationMode.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/provider/XOAuthIssuerValidationMode.java
@@ -1,0 +1,6 @@
+package org.cloudfoundry.identity.uaa.provider;
+
+public enum XOAuthIssuerValidationMode {
+    STRICT,
+    DOMAIN_ONLY
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/codestore/ExpiringCodeStore.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/codestore/ExpiringCodeStore.java
@@ -31,6 +31,19 @@ public interface ExpiringCodeStore {
     ExpiringCode generateCode(String data, Timestamp expiresAt, String intent, String zoneId);
 
     /**
+     * Retrieve a code BUT DO NOT DELETE IT.
+     *
+     * WARNING - if you intend to expire the code as soon as you read it,
+     * use {@link #retrieveCode(String, String)} instead.
+     *
+     * @param code the one-time code to look for
+     * @param zoneId
+     * @return code or null if the code is not found
+     * @throws java.lang.NullPointerException if the code is null
+     */
+    ExpiringCode peekCode(String code, String zoneId);
+
+    /**
      * Retrieve a code and delete it if it exists.
      *
      * @param code the one-time code to look for

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/codestore/JdbcExpiringCodeStore.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/codestore/JdbcExpiringCodeStore.java
@@ -112,6 +112,25 @@ public class JdbcExpiringCodeStore implements ExpiringCodeStore {
     }
 
     @Override
+    public ExpiringCode peekCode(String code, String zoneId) {
+        cleanExpiredEntries();
+
+        if (code == null) {
+            throw new NullPointerException();
+        }
+
+        try {
+            ExpiringCode expiringCode = jdbcTemplate.queryForObject(selectAllFields, rowMapper, code, zoneId);
+            if (expiringCode.getExpiresAt().getTime() < timeService.getCurrentTimeMillis()) {
+                expiringCode = null;
+            }
+            return expiringCode;
+        } catch (EmptyResultDataAccessException x) {
+            return null;
+        }
+    }
+
+    @Override
     public ExpiringCode retrieveCode(String code, String zoneId) {
         cleanExpiredEntries();
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/invitations/InvitationsController.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/invitations/InvitationsController.java
@@ -104,7 +104,7 @@ public class InvitationsController {
     @RequestMapping(value = "/accept", method = GET, params = {"code"})
     public String acceptInvitePage(@RequestParam String code, Model model, HttpServletRequest request, HttpServletResponse response) {
 
-        ExpiringCode expiringCode = expiringCodeStore.retrieveCode(code, IdentityZoneHolder.get().getId());
+        ExpiringCode expiringCode = expiringCodeStore.peekCode(code, IdentityZoneHolder.get().getId());
         if ((null == expiringCode) || (null != expiringCode.getIntent() && !INVITATION.name().equals(expiringCode.getIntent()))) {
             return handleUnprocessableEntity(model, response, "error_message_code", "code_expired", "invitations/accept_invite");
         }
@@ -116,7 +116,6 @@ public class InvitationsController {
         String origin = codeData.get(ORIGIN);
         try {
             IdentityProvider provider = identityProviderProvisioning.retrieveByOrigin(origin, IdentityZoneHolder.get().getId());
-            final String newCode = expiringCodeStore.generateCode(expiringCode.getData(), new Timestamp(System.currentTimeMillis() + (10 * 60 * 1000)), expiringCode.getIntent(), IdentityZoneHolder.get().getId()).getCode();
 
             UaaUser user = userDatabase.retrieveUserById(codeData.get("user_id"));
             boolean isUaaUserAndVerified =
@@ -124,12 +123,12 @@ public class InvitationsController {
             boolean isExternalUserAndAcceptedInvite =
                     !UAA.equals(provider.getType()) && UaaHttpRequestUtils.isAcceptedInvitationAuthentication();
             if (isUaaUserAndVerified || isExternalUserAndAcceptedInvite) {
-                AcceptedInvitation accepted = invitationsService.acceptInvitation(newCode, "");
+                AcceptedInvitation accepted = invitationsService.acceptInvitation(code, "");
                 String redirect = "redirect:" + accepted.getRedirectUri();
                 logger.debug(String.format("Redirecting accepted invitation for email:%s, id:%s to URL:%s", codeData.get("email"), codeData.get("user_id"), redirect));
                 return redirect;
             } else if (SAML.equals(provider.getType())) {
-                setRequestAttributes(request, newCode, user);
+                setRequestAttributes(request, code, user);
 
                 SamlIdentityProviderDefinition definition = ObjectUtils.castInstance(provider.getConfig(), SamlIdentityProviderDefinition.class);
 
@@ -137,7 +136,7 @@ public class InvitationsController {
                 logger.debug(String.format("Redirecting invitation for email:%s, id:%s single SAML IDP URL:%s", codeData.get("email"), codeData.get("user_id"), redirect));
                 return redirect;
             } else if (OIDC10.equals(provider.getType()) || OAUTH20.equals(provider.getType())) {
-                setRequestAttributes(request, newCode, user);
+                setRequestAttributes(request, code, user);
 
                 AbstractXOAuthIdentityProviderDefinition definition = ObjectUtils.castInstance(provider.getConfig(), AbstractXOAuthIdentityProviderDefinition.class);
 
@@ -155,7 +154,7 @@ public class InvitationsController {
                         Collections.singletonList(UaaAuthority.UAA_INVITED));
                 SecurityContextHolder.getContext().setAuthentication(token);
                 model.addAttribute("provider", provider.getType());
-                model.addAttribute("code", newCode);
+                model.addAttribute("code", code);
                 model.addAttribute("email", codeData.get("email"));
                 logger.debug(String.format("Sending user to accept invitation page email:%s, id:%s", codeData.get("email"), codeData.get("user_id")));
             }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -869,6 +869,19 @@ public class LoginInfoEndpoint {
         return PASSCODE;
     }
 
+    @RequestMapping(value = {
+        "/p",
+        "/pa",
+        "/pas",
+        "/pass",
+        "/passc",
+        "/passco",
+        "/passcod"
+    }, method = GET)
+    public String redirectToGeneratePasscode(Map<String, Object> model, Principal principal) {
+        return "redirect:/passcode";
+    }
+
     private Map<String, ?> getLinksInfo() {
 
         Map<String, Object> model = new HashMap<>();

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/TokenValidationService.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/TokenValidationService.java
@@ -2,6 +2,7 @@ package org.cloudfoundry.identity.uaa.oauth;
 
 import org.cloudfoundry.identity.uaa.oauth.token.RevocableToken;
 import org.cloudfoundry.identity.uaa.oauth.token.RevocableTokenProvisioning;
+import org.cloudfoundry.identity.uaa.provider.XOAuthIssuerValidationMode;
 import org.cloudfoundry.identity.uaa.user.UaaUser;
 import org.cloudfoundry.identity.uaa.user.UaaUserDatabase;
 import org.cloudfoundry.identity.uaa.util.TokenValidation;
@@ -52,7 +53,7 @@ public class TokenValidationService {
                 buildAccessTokenValidator(token, keyInfoService) : buildRefreshTokenValidator(token, keyInfoService);
         tokenValidation
                 .checkRevocableTokenStore(revocableTokenProvisioning)
-                .checkIssuer(tokenEndpointBuilder.getTokenEndpoint(IdentityZoneHolder.get()));
+                .checkIssuer(tokenEndpointBuilder.getTokenEndpoint(IdentityZoneHolder.get()), XOAuthIssuerValidationMode.STRICT);
 
         ClientDetails client = tokenValidation.getClientDetails(multitenantClientServices);
         UaaUser user = tokenValidation.getUserDetails(userDatabase);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIDPWrapperFactoryBean.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIDPWrapperFactoryBean.java
@@ -19,6 +19,7 @@ import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
 import org.cloudfoundry.identity.uaa.provider.IdentityProviderWrapper;
 import org.cloudfoundry.identity.uaa.provider.OIDCIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.provider.RawXOAuthIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.XOAuthIssuerValidationMode;
 import org.cloudfoundry.identity.uaa.util.JsonUtils;
 
 import java.net.MalformedURLException;
@@ -110,6 +111,18 @@ public class OauthIDPWrapperFactoryBean {
         idpDefinition.setSkipSslValidation(idpDefinitionMap.get("skipSslValidation") == null ? false : (boolean) idpDefinitionMap.get("skipSslValidation"));
         idpDefinition.setTokenKey((String) idpDefinitionMap.get("tokenKey"));
         idpDefinition.setIssuer((String) idpDefinitionMap.get("issuer"));
+
+        XOAuthIssuerValidationMode issuerValidationMode = XOAuthIssuerValidationMode.STRICT;
+        String issuerValidationModeText = (String)idpDefinitionMap.get("issuerValidationMode");
+        if (hasText(issuerValidationModeText)) {
+            try {
+                issuerValidationMode = XOAuthIssuerValidationMode.valueOf(issuerValidationModeText.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("issuer validation mode is malformed.", e);
+            }
+        }
+        idpDefinition.setIssuerValidationMode(issuerValidationMode);
+
         idpDefinition.setAttributeMappings((Map<String, Object>) idpDefinitionMap.get(ATTRIBUTE_MAPPINGS));
         idpDefinition.setScopes((List<String>) idpDefinitionMap.get("scopes"));
         String responseType = (String) idpDefinitionMap.get("responseType");

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthAuthenticationManager.java
@@ -15,6 +15,13 @@ package org.cloudfoundry.identity.uaa.provider.oauth;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.commons.codec.binary.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.cloudfoundry.identity.uaa.provider.AbstractXOAuthIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
+import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
+import org.cloudfoundry.identity.uaa.provider.OIDCIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.RawXOAuthIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
 import org.cloudfoundry.identity.uaa.authentication.manager.ExternalGroupAuthorizationEvent;
 import org.cloudfoundry.identity.uaa.authentication.manager.ExternalLoginAuthenticationManager;
@@ -29,11 +36,6 @@ import org.cloudfoundry.identity.uaa.oauth.jwt.ChainedSignatureVerifier;
 import org.cloudfoundry.identity.uaa.oauth.jwt.Jwt;
 import org.cloudfoundry.identity.uaa.oauth.jwt.JwtHelper;
 import org.cloudfoundry.identity.uaa.oauth.token.ClaimConstants;
-import org.cloudfoundry.identity.uaa.provider.AbstractXOAuthIdentityProviderDefinition;
-import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
-import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
-import org.cloudfoundry.identity.uaa.provider.OIDCIdentityProviderDefinition;
-import org.cloudfoundry.identity.uaa.provider.RawXOAuthIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.user.UaaUser;
 import org.cloudfoundry.identity.uaa.user.UaaUserPrototype;
 import org.cloudfoundry.identity.uaa.util.JsonUtils;
@@ -521,7 +523,7 @@ public class XOAuthAuthenticationManager extends ExternalLoginAuthenticationMana
         } else {
             JsonWebKeySet<JsonWebKey> tokenKeyFromOAuth = getTokenKeyFromOAuth(config);
             validation = buildIdTokenValidator(idToken, new ChainedSignatureVerifier(tokenKeyFromOAuth), keyInfoService)
-                .checkIssuer((isEmpty(config.getIssuer()) ? config.getTokenUrl().toString() : config.getIssuer()))
+                .checkIssuer((isEmpty(config.getIssuer()) ? config.getTokenUrl().toString() : config.getIssuer()), config.getIssuerValidationMode())
                 .checkAudience(config.getRelyingPartyId());
         }
         return validation.checkExpiry();

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/TokenValidation.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/TokenValidation.java
@@ -15,6 +15,7 @@ package org.cloudfoundry.identity.uaa.util;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.cloudfoundry.identity.uaa.provider.XOAuthIssuerValidationMode;
 import org.cloudfoundry.identity.uaa.oauth.KeyInfo;
 import org.cloudfoundry.identity.uaa.oauth.KeyInfoService;
 import org.cloudfoundry.identity.uaa.oauth.TokenRevokedException;
@@ -39,6 +40,8 @@ import org.springframework.security.oauth2.provider.NoSuchClientException;
 import org.springframework.util.Assert;
 
 import javax.validation.constraints.NotNull;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.time.Instant;
 import java.util.*;
 import java.util.function.Function;
@@ -124,7 +127,7 @@ public abstract class TokenValidation {
         return this;
     }
 
-    public TokenValidation checkIssuer(String issuer) {
+    public TokenValidation checkIssuer(String issuer, XOAuthIssuerValidationMode validationMode) {
         if (issuer == null) {
             return this;
         }
@@ -133,10 +136,40 @@ public abstract class TokenValidation {
             throw new InvalidTokenException("Token does not bear an ISS claim.", null);
         }
 
-        if (!equals(issuer, claims.get(ISS))) {
-            throw new InvalidTokenException("Invalid issuer (" + claims.get(ISS) + ") for token did not match expected: " + issuer, null);
+        switch (validationMode) {
+            case STRICT: {
+                if (!equals(issuer, claims.get(ISS))) {
+                    throw new InvalidTokenException("Invalid issuer (" + claims.get(ISS) + ") for token did not match expected: " + issuer, null);
+                }
+                return this;
+            }
+            case DOMAIN_ONLY: {
+                URL issuerUrl;
+                try {
+                    issuerUrl = new URL(issuer);
+                }
+                catch (MalformedURLException e) {
+                    throw new InvalidTokenException("Issuer is a malformed URL.", e);
+                }
+
+                URL claimUrl;
+                try
+                {
+                    claimUrl = new URL((String)claims.get(ISS));
+                }
+                catch (MalformedURLException e) {
+                    throw new InvalidTokenException("Issuer claim is a malformed URL.", e);
+                }
+
+                if (!equals(issuerUrl.getHost(), claimUrl.getHost())) {
+                    throw new InvalidTokenException("Invalid issuer domain (" + claimUrl.getHost() + ") for token did not match expected: " + issuerUrl.getHost(), null);
+                }
+                return this;
+            }
+            default: {
+                throw new IllegalArgumentException("Unknown enum value: " + validationMode);
+            }
         }
-        return this;
     }
 
     protected TokenValidation checkExpiry(Instant asOf) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/codestore/ExpiringCodeStoreTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/codestore/ExpiringCodeStoreTests.java
@@ -134,6 +134,19 @@ public class ExpiringCodeStoreTests extends JdbcTestBase {
     }
 
     @Test
+    public void testPeekCode() {
+        String data = "{}";
+        Timestamp expiresAt = new Timestamp(System.currentTimeMillis() + 60000);
+        String zoneId = IdentityZoneHolder.get().getId();
+
+        ExpiringCode generatedCode = expiringCodeStore.generateCode(data, expiresAt, null, zoneId);
+
+        Assert.assertEquals(generatedCode, expiringCodeStore.peekCode(generatedCode.getCode(), zoneId));
+        Assert.assertEquals(generatedCode, expiringCodeStore.peekCode(generatedCode.getCode(), zoneId));
+        Assert.assertEquals(generatedCode, expiringCodeStore.peekCode(generatedCode.getCode(), zoneId));
+    }
+
+    @Test
     public void testRetrieveCode() {
         String data = "{}";
         Timestamp expiresAt = new Timestamp(System.currentTimeMillis() + 60000);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/codestore/InMemoryExpiringCodeStore.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/codestore/InMemoryExpiringCodeStore.java
@@ -41,6 +41,21 @@ public class InMemoryExpiringCodeStore implements ExpiringCodeStore {
     }
 
     @Override
+    public ExpiringCode peekCode(String code, String zoneId) {
+        if (code == null) {
+            throw new NullPointerException();
+        }
+
+        ExpiringCode expiringCode = store.get(code + zoneId);
+
+        if (expiringCode == null || isExpired(expiringCode)) {
+            expiringCode = null;
+        }
+
+        return expiringCode;
+    }
+
+    @Override
     public ExpiringCode retrieveCode(String code, String zoneId) {
         if (code == null) {
             throw new NullPointerException();

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/invitations/InvitationsControllerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/invitations/InvitationsControllerTest.java
@@ -148,8 +148,7 @@ public class InvitationsControllerTest {
         codeData.put("email", "user@example.com");
         codeData.put("client_id", "client-id");
         codeData.put("redirect_uri", "blah.test.com");
-        when(expiringCodeStore.retrieveCode("code", IdentityZoneHolder.get().getId())).thenReturn(createCode(codeData), null);
-        when(expiringCodeStore.generateCode(anyString(), any(), eq(INVITATION.name()), eq(IdentityZoneHolder.get().getId()))).thenReturn(createCode(codeData));
+        when(expiringCodeStore.peekCode("code", IdentityZoneHolder.get().getId())).thenReturn(createCode(codeData), null);
         IdentityProvider provider = new IdentityProvider();
         provider.setType(OriginKeys.UAA);
         when(providerProvisioning.retrieveByOrigin(any(), any())).thenReturn(provider);
@@ -191,8 +190,7 @@ public class InvitationsControllerTest {
     @Test
     public void acceptInvitePage_for_unverifiedSamlUser() throws Exception {
         Map<String,String> codeData = getInvitationsCode("test-saml");
-        when(expiringCodeStore.retrieveCode("the_secret_code", IdentityZoneHolder.get().getId())).thenReturn(createCode(codeData));
-        when(expiringCodeStore.generateCode(anyString(), any(), eq(INVITATION.name()), eq(IdentityZoneHolder.get().getId()))).thenReturn(createCode(codeData));
+        when(expiringCodeStore.peekCode("the_secret_code", IdentityZoneHolder.get().getId())).thenReturn(createCode(codeData));
         IdentityProvider provider = new IdentityProvider();
         SamlIdentityProviderDefinition definition = new SamlIdentityProviderDefinition()
             .setMetaDataLocation("http://test.saml.com")
@@ -218,8 +216,7 @@ public class InvitationsControllerTest {
     @Test
     public void acceptInvitePage_for_unverifiedOIDCUser() throws Exception {
         Map<String,String> codeData = getInvitationsCode("test-oidc");
-        when(expiringCodeStore.retrieveCode("the_secret_code", IdentityZoneHolder.get().getId())).thenReturn(createCode(codeData));
-        when(expiringCodeStore.generateCode(anyString(), any(), eq(INVITATION.name()), eq(IdentityZoneHolder.get().getId()))).thenReturn(createCode(codeData));
+        when(expiringCodeStore.peekCode("the_secret_code", IdentityZoneHolder.get().getId())).thenReturn(createCode(codeData));
 
         OIDCIdentityProviderDefinition definition = new OIDCIdentityProviderDefinition();
         definition.setAuthUrl(new URL("https://oidc10.auth.url"));
@@ -243,8 +240,7 @@ public class InvitationsControllerTest {
     @Test
     public void acceptInvitePage_for_unverifiedLdapUser() throws Exception {
         Map<String, String> codeData = getInvitationsCode(LDAP);
-        when(expiringCodeStore.retrieveCode("the_secret_code", IdentityZoneHolder.get().getId())).thenReturn(createCode(codeData));
-        when(expiringCodeStore.generateCode(anyString(), any(), eq(INVITATION.name()), eq(IdentityZoneHolder.get().getId()))).thenReturn(createCode(codeData));
+        when(expiringCodeStore.peekCode("the_secret_code", IdentityZoneHolder.get().getId())).thenReturn(createCode(codeData));
 
         IdentityProvider provider = new IdentityProvider();
         provider.setType(LDAP);
@@ -259,7 +255,7 @@ public class InvitationsControllerTest {
                 .andExpect(content().string(containsString("Email: " + "user@example.com")))
                 .andExpect(content().string(containsString("Sign in with enterprise credentials:")))
                 .andExpect(content().string(containsString("username")))
-                .andExpect(model().attribute("code", "code"))
+                .andExpect(model().attribute("code", "the_secret_code"))
                 .andReturn();
     }
 
@@ -393,8 +389,7 @@ public class InvitationsControllerTest {
         codeData.put("email", "user@example.com");
         codeData.put("origin", "some-origin");
 
-        when(expiringCodeStore.retrieveCode("the_secret_code", IdentityZoneHolder.get().getId())).thenReturn(createCode(codeData), null);
-        when(expiringCodeStore.generateCode(anyString(), any(), eq(INVITATION.name()), eq(IdentityZoneHolder.get().getId()))).thenReturn(createCode(codeData));
+        when(expiringCodeStore.peekCode("the_secret_code", IdentityZoneHolder.get().getId())).thenReturn(createCode(codeData), null);
         when(invitationsService.acceptInvitation(anyString(), eq(""))).thenReturn(new AcceptedInvitation("blah.test.com", new ScimUser()));
         IdentityProvider provider = new IdentityProvider();
         provider.setType(OriginKeys.UAA);
@@ -664,10 +659,8 @@ public class InvitationsControllerTest {
         Map<String,String> codeData = getInvitationsCode(OriginKeys.UAA);
         String codeDataString = JsonUtils.writeValueAsString(codeData);
         ExpiringCode expiringCode = new ExpiringCode("thecode", new Timestamp(1), codeDataString, INVITATION.name());
-        when(expiringCodeStore.retrieveCode("thecode", IdentityZoneHolder.get().getId()))
+        when(expiringCodeStore.peekCode("thecode", IdentityZoneHolder.get().getId()))
             .thenReturn(expiringCode, null);
-        when(expiringCodeStore.generateCode(anyString(), any(), eq(INVITATION.name()), eq(IdentityZoneHolder.get().getId())))
-            .thenReturn(expiringCode);
 
         mockMvc.perform(get("/invitations/accept")
             .param("code", "thecode"))
@@ -710,6 +703,8 @@ public class InvitationsControllerTest {
         Map<String,String> codeData = getInvitationsCode(OriginKeys.UAA);
         String codeDataString = JsonUtils.writeValueAsString(codeData);
         ExpiringCode expiringCode = new ExpiringCode("thecode", new Timestamp(1), codeDataString, INVITATION.name());
+        when(expiringCodeStore.peekCode(anyString(), eq(IdentityZoneHolder.get().getId())))
+            .thenReturn(expiringCode);
         when(expiringCodeStore.retrieveCode(anyString(), eq(IdentityZoneHolder.get().getId())))
             .thenReturn(expiringCode);
         when(expiringCodeStore.generateCode(anyString(), any(), eq(INVITATION.name()), eq(IdentityZoneHolder.get().getId())))

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/TokenValidationServiceTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/TokenValidationServiceTest.java
@@ -125,6 +125,24 @@ public class TokenValidationServiceTest {
     }
 
     @Test
+    public void validationFails_whenIssuerDoesNotMatchTokenEndPointExactly() {
+        String tokenEndpoint = "https://token.endpoint";
+        String issuer = tokenEndpoint + "/does/not/match";
+
+        when(tokenEndpointBuilder.getTokenEndpoint(IdentityZoneHolder.get())).thenReturn(tokenEndpoint);
+
+        expectedException.expect(InvalidTokenException.class);
+        expectedException.expectMessage("Invalid issuer (" + issuer + ") for token did not match expected: " + tokenEndpoint);
+
+        content.put(ISS, issuer);
+
+        when(mockMultitenantClientServices.loadClientByClientId(clientId, IdentityZoneHolder.get().getId())).thenThrow(NoSuchClientException.class);
+        String accessToken = UaaTokenUtils.constructToken(header, content, signer);
+
+        tokenValidationService.validateToken(accessToken, true);
+    }
+
+    @Test
     public void refreshToken_validatesWithScopeClaim_forBackwardsCompatibilityReasons() {
         Map<String, Object> content = map(
                 entry(USER_ID, userId),

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthAuthenticationManagerIT.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthAuthenticationManagerIT.java
@@ -222,6 +222,7 @@ public class XOAuthAuthenticationManagerIT {
                 .setAuthUrl(new URL("http://localhost/oauth/authorize"))
                 .setTokenUrl(new URL("http://localhost/oauth/token"))
                 .setIssuer("http://localhost/oauth/token")
+                .setIssuerValidationMode(XOAuthIssuerValidationMode.STRICT)
                 .setShowLinkText(true)
                 .setLinkText("My OIDC Provider")
                 .setRelyingPartyId("identity")

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/TokenValidationTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/TokenValidationTest.java
@@ -23,6 +23,7 @@ import org.cloudfoundry.identity.uaa.oauth.jwt.ChainedSignatureVerifier;
 import org.cloudfoundry.identity.uaa.oauth.token.ClaimConstants;
 import org.cloudfoundry.identity.uaa.oauth.token.RevocableToken;
 import org.cloudfoundry.identity.uaa.oauth.token.RevocableTokenProvisioning;
+import org.cloudfoundry.identity.uaa.provider.XOAuthIssuerValidationMode;
 import org.cloudfoundry.identity.uaa.test.TestUtils;
 import org.cloudfoundry.identity.uaa.user.InMemoryUaaUserDatabase;
 import org.cloudfoundry.identity.uaa.user.MockUaaUserDatabase;
@@ -333,7 +334,7 @@ public class TokenValidationTest {
     @Test
     public void checking_token_happy_case() {
         buildAccessTokenValidator(getToken(), new KeyInfoService("https://localhost"))
-                .checkIssuer("http://localhost:8080/uaa/oauth/token")
+                .checkIssuer("http://localhost:8080/uaa/oauth/token", XOAuthIssuerValidationMode.STRICT)
                 .checkClient((clientId) -> inMemoryMultitenantClientServices.loadClientByClientId(clientId))
                 .checkExpiry(oneSecondBeforeTheTokenExpires)
                 .checkUser((uid) -> userDb.retrieveUserById(uid))
@@ -379,7 +380,7 @@ public class TokenValidationTest {
         buildAccessTokenValidator(
                 getToken(Arrays.asList(EMAIL, USER_NAME)), new KeyInfoService("https://localhost"))
                 .checkSignature(verifier)
-                .checkIssuer("http://localhost:8080/uaa/oauth/token")
+                .checkIssuer("http://localhost:8080/uaa/oauth/token", XOAuthIssuerValidationMode.STRICT)
                 .checkClient((clientId) -> inMemoryMultitenantClientServices.loadClientByClientId(clientId))
                 .checkExpiry(oneSecondBeforeTheTokenExpires)
                 .checkUser((uid) -> userDb.retrieveUserById(uid))
@@ -432,10 +433,18 @@ public class TokenValidationTest {
     }
 
     @Test
-    public void tokenWithInvalidIssuer() {
+    public void tokenWithInvalidIssuer_AndStrictIssuerValidation() {
         expectedException.expect(InvalidTokenException.class);
 
-        buildAccessTokenValidator(getToken(), new KeyInfoService("https://localhost")).checkIssuer("http://wrong.issuer/");
+        buildAccessTokenValidator(getToken(), new KeyInfoService("https://localhost")).checkIssuer("http://wrong.issuer/", XOAuthIssuerValidationMode.STRICT);
+    }
+
+    @Test
+    public void tokenWithMatchingDomain_andDomainOnlyIssuerValidation_passesValidation() {
+        buildAccessTokenValidator(
+            getToken(),
+            new KeyInfoService("https://localhost")
+        ).checkIssuer("http://localhost/another/path/segment", XOAuthIssuerValidationMode.DOMAIN_ONLY);
     }
 
     @Test
@@ -444,7 +453,7 @@ public class TokenValidationTest {
         TokenValidation validation = buildAccessTokenValidator(getToken(), new KeyInfoService("https://localhost"));
 
         expectedException.expect(InvalidTokenException.class);
-        validation.checkIssuer("http://localhost:8080/uaa/oauth/token");
+        validation.checkIssuer("http://localhost:8080/uaa/oauth/token", XOAuthIssuerValidationMode.STRICT);
     }
 
     @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/InvitationsServiceMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/InvitationsServiceMockMvcTests.java
@@ -207,7 +207,7 @@ public class InvitationsServiceMockMvcTests {
     }
 
     @Test
-    void acceptInvitationForUaaUserShouldExpireInvitelink() throws Exception {
+    void acceptInvitationForUaaUserShouldNotExpireInvitelink() throws Exception {
         String email = new RandomValueStringGenerator().generate().toLowerCase() + "@test.org";
         URL inviteLink = inviteUser(webApplicationContext, mockMvc, email, userInviteToken, null, clientId, OriginKeys.UAA);
         assertEquals(OriginKeys.UAA, queryUserForField(jdbcTemplate, email, OriginKeys.ORIGIN, String.class));
@@ -218,9 +218,10 @@ public class InvitationsServiceMockMvcTests {
                 .accept(MediaType.TEXT_HTML);
         mockMvc.perform(get)
                 .andExpect(status().isOk());
-
         mockMvc.perform(get)
-                .andExpect(status().isUnprocessableEntity());
+            .andExpect(status().isOk());
+        mockMvc.perform(get)
+                .andExpect(status().isOk());
     }
 
     @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/PasscodeMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/PasscodeMockMvcTests.java
@@ -98,6 +98,13 @@ class PasscodeMockMvcTests {
     }
 
     @Test
+    void testRedirectToPasscodePage() throws Exception {
+        mockMvc.perform(get("/pa"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().string("Location", "/passcode"));
+    }
+
+    @Test
     void testLoginUsingPasscodeWithSamlToken() throws Exception {
         ExpiringUsernameAuthenticationToken et = new ExpiringUsernameAuthenticationToken(USERNAME, null);
         UaaAuthentication auth = new LoginSamlAuthenticationToken(marissa, et).getUaaAuthentication(


### PR DESCRIPTION
The CF CLI prints out a url when a user tries to log in with SSO:
`https://login.cloud.service.gov.uk/passcode` in Ireland and
`https://login.london/cloud.service.gov.uk/passcode` in London.

Some shells interpret the link and make it clickable… but because the
URL is so long part of `/passcode` gets trimmed onto the next line.
The shells seem to miss out on that, which is silly because the
newline is a formatting thing rather than an actual "\n".

This means that on at least half a dozen different occasions our users
have gone to `https://login.cloud.service.gov.uk/pa` or
`https://login.cloud.service.gov.uk/passco`. Those got back vague
error messages which discouraged the user from trying to solve the
problem themselves.

This commit redirect `/p`, `/pa`, `/pas`, …, `/passcod` to the
passcode page, so that things start magically working for these users.